### PR TITLE
polyline checks in planning

### DIFF
--- a/src/integral_timber_joints/planning/parsing.py
+++ b/src/integral_timber_joints/planning/parsing.py
@@ -169,12 +169,14 @@ def archive_movements(target_process, beam_ids, process_folder_path, movement_id
 
 def reset_movements(source_process: RobotClampAssemblyProcess, target_process: RobotClampAssemblyProcess,
         beam_ids, movement_id=None, options=None):
+    options = options or {}
     use_stored_seed = options.get('use_stored_seed', False)
     target_movement_ids = target_movement_ids_from_beam_ids(target_process, beam_ids, movement_id)
+    saved_seed = None
     for m_id in target_movement_ids:
         target_m = target_process.get_movement_by_movement_id(m_id)
-        saved_seed = copy(target_m.seed)
+        if use_stored_seed and hasattr(target_m, 'seed'):
+            saved_seed = copy(target_m.seed)
         target_m.data = source_process.get_movement_by_movement_id(m_id).data
-        if use_stored_seed:
-            LOGGER.info(saved_seed)
+        if use_stored_seed and hasattr(target_m, 'seed'):
             target_m.seed = saved_seed

--- a/src/integral_timber_joints/planning/parsing.py
+++ b/src/integral_timber_joints/planning/parsing.py
@@ -1,8 +1,7 @@
 import os
 import shutil
 import json
-from copy import deepcopy
-from compas_fab.backends.pybullet.utils import LOG
+from copy import deepcopy, copy
 from termcolor import colored
 
 from compas.robots import RobotModel
@@ -169,8 +168,13 @@ def archive_movements(target_process, beam_ids, process_folder_path, movement_id
         move_saved_movement(target_m, process_folder_path)
 
 def reset_movements(source_process: RobotClampAssemblyProcess, target_process: RobotClampAssemblyProcess,
-        beam_ids, movement_id=None):
+        beam_ids, movement_id=None, options=None):
+    use_stored_seed = options.get('use_stored_seed', False)
     target_movement_ids = target_movement_ids_from_beam_ids(target_process, beam_ids, movement_id)
     for m_id in target_movement_ids:
         target_m = target_process.get_movement_by_movement_id(m_id)
+        saved_seed = copy(target_m.seed)
         target_m.data = source_process.get_movement_by_movement_id(m_id).data
+        if use_stored_seed:
+            LOGGER.info(saved_seed)
+            target_m.seed = saved_seed

--- a/src/integral_timber_joints/planning/run.py
+++ b/src/integral_timber_joints/planning/run.py
@@ -42,9 +42,6 @@ def plan_for_beam_id_with_restart(client, robot, process, beam_id, args, options
 
     The client will be recreated at each restart as well.
     """
-    result_path = get_process_path(args.design_dir, args.problem, subdir=args.problem_subdir)
-    ext_movement_path = os.path.dirname(result_path)
-    # ---
     solve_timeout = options.get('solve_timeout', 600)
     # max solve iter kept rather high to prioritize timeout
     solve_iters = options.get('solve_iters', 40)
@@ -326,7 +323,7 @@ def main():
     if not args.no_smooth:
         options.update({
             'smooth_iterations' : 150,
-            'max_smooth_time' : 60,
+            'max_smooth_time' : 180,
              })
     if args.buffers_for_free_motions:
         options.update({

--- a/src/integral_timber_joints/planning/run.py
+++ b/src/integral_timber_joints/planning/run.py
@@ -59,7 +59,7 @@ def plan_for_beam_id_with_restart(client, robot, process, beam_id, args, options
         process = parse_process(args.design_dir, args.problem, subdir=args.problem_subdir)
 
         # ! reset target movements from the original, unplanned process file
-        reset_movements(source_process, process, [beam_id], movement_id=args.movement_id)
+        reset_movements(source_process, process, [beam_id], movement_id=args.movement_id, options=options)
 
         # # * load previously planned movements
         # loaded_movements = process.load_external_movements(ext_movement_path)

--- a/src/integral_timber_joints/planning/solve.py
+++ b/src/integral_timber_joints/planning/solve.py
@@ -89,22 +89,23 @@ def compute_movement(client, robot, process, movement, options=None, diagnosis=F
     if not isinstance(movement, RoboticMovement):
         return None
     options = options or {}
-    # * low_res mode is used to quickly get a feeling of the planning problem
     verbose = options.get('verbose', True)
-    joint_compare_tolerances = options.get('joint_compare_tolerances', {})
     if verbose:
         LOGGER.debug(colored(movement.short_summary, 'cyan'))
 
-    # use_stored_seed = options.get('use_stored_seed', False)
-    # set seed stored in the movement
-    # if use_stored_seed:
-    #     seed = movement.seed
-    #     assert seed is not None, 'No meaningful seed saved in the movement.'
-    # else:
-    #     seed = get_random_seed()
-    #     movement.seed = seed
-    # set_random_seed(seed)
-    # set_numpy_seed(seed)
+    use_stored_seed = options.get('use_stored_seed', False)
+    # * set seed stored in the movement
+    seed = None
+    if use_stored_seed:
+        seed = movement.seed
+        if seed is None:
+            LOGGER.warning(f'No meaningful seed saved in movement {movement.movement_id}.')
+        LOGGER.debug(f'using seed {seed}')
+    if seed is None:
+        seed = hash(time.time())
+        movement.seed = seed
+    set_random_seed(seed)
+    set_numpy_seed(seed)
 
     # * custom limits
     traj = None

--- a/src/integral_timber_joints/planning/stream.py
+++ b/src/integral_timber_joints/planning/stream.py
@@ -431,7 +431,7 @@ def compute_free_movement(client: PyChoreoClient, robot: Robot, process: RobotCl
                         if verbose: LOGGER.debug('End conf sample found after {} gantry iters.'.format(gantry_iter))
                         if debug:
                                 client.set_robot_configuration(robot, orig_end_conf)
-                                LOGGER.debug(orig_end_conf.joint_values)
+                                # LOGGER.debug(orig_end_conf.joint_values)
                                 wait_if_gui('Sampled end conf')
                         break
                 if sample_found:

--- a/tests/test_plan_movement_with_seed.py
+++ b/tests/test_plan_movement_with_seed.py
@@ -1,0 +1,124 @@
+import os
+import json
+import logging
+import argparse
+
+from compas.utilities import DataDecoder, DataEncoder
+from compas_fab_pychoreo.utils import is_configurations_close
+from compas_fab_pychoreo.utils import LOGGER as PYCHOREO_LOGGER
+
+from integral_timber_joints.planning.solve import compute_movement
+from integral_timber_joints.planning.robot_setup import load_RFL_world, get_tolerances
+from integral_timber_joints.planning.utils import beam_ids_from_argparse_seq_n, LOGGER
+from integral_timber_joints.planning.parsing import parse_process, save_process, save_movements, get_process_path, \
+    reset_movements, archive_movements
+from integral_timber_joints.planning.state import set_state, set_initial_state
+
+HERE = os.path.dirname(__file__)
+
+def save_trajectory(traj, file_name='tmp_traj.json'):
+    HERE = os.path.dirname(__file__)
+    save_path = os.path.join(HERE, file_name)
+    with open(save_path, 'w') as f:
+        json.dump(traj, f, cls=DataEncoder, indent=None, sort_keys=True)
+
+def parse_trajectory(file_name='tmp_traj.json'):
+    save_path = os.path.join(HERE, file_name)
+    with open(save_path, 'r') as f:
+        traj = json.load(f, cls=DataDecoder)
+    return traj
+
+def compare_trajectories(traj0, traj1, options=None):
+    options = options or {}
+    assert len(traj0.points) == len(traj1.points)
+    for conf0, conf1 in zip(traj0.points, traj1.points):
+        assert is_configurations_close(conf0, conf1, options=options)
+
+################################
+
+def solve_for_movement(client, robot, process, args, options):
+    use_stored_seed = options.get('use_stored_seed', False)
+    if args.movement_id.startswith('A'):
+        m = process.get_movement_by_movement_id(args.movement_id)
+    else:
+        m = process.movements[int(args.movement_id)]
+
+    assert compute_movement(client, robot, process, m, options=options)
+
+    if not use_stored_seed:
+        # movements without trajectories but end conf set will be saved into the WIP process file
+        save_process(args.design_dir, args.problem, process, save_dir=args.problem_subdir)
+        save_movements(args.design_dir, [m], save_dir=args.problem_subdir, movement_subdir='movements')
+        save_trajectory(m.trajectory, f'{m.movement_id}_trajectory.json')
+    else:
+        parsed_traj = parse_trajectory(f'{m.movement_id}_trajectory.json')
+        compare_trajectories(m.trajectory, parsed_traj, options)
+
+#################################
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--design_dir', default='210419_HyparHut',
+                        help='problem json\'s containing folder\'s name.')
+    parser.add_argument('--problem', default='Shelter_process.json', # twelve_pieces_process.json
+                        help='The name of the problem to solve (json file\'s name, e.g. "nine_pieces_process.json")')
+    parser.add_argument('--problem_subdir', default='seed_test',
+                        help='subdir for saving movements, default to `seed_test`.')
+    #
+    parser.add_argument('--movement_id', type=str, help='Compute only for movement with a specific tag, e.g. `A54_M0`.')
+    parser.add_argument('--use_stored_seed', action='store_true', help='Use existing seed.')
+    parser.add_argument('--no_smooth', action='store_true', help='Not apply smoothing on free motions upon a plan is found. Defaults to False.')
+    #
+    parser.add_argument('--debug', action='store_true', help='Debug mode.')
+    parser.add_argument('--diagnosis', action='store_true', help='Diagnosis mode, show collisions whenever encountered')
+    parser.add_argument('--quiet', action='store_true', help='Disable print out verbose. Defaults to False.')
+    args = parser.parse_args()
+
+    logging_level = logging.DEBUG if args.debug else logging.INFO
+    LOGGER.setLevel(logging_level)
+    PYCHOREO_LOGGER.setLevel(logging_level)
+
+    # * Connect to path planning backend and initialize robot parameters
+    client, robot, _ = load_RFL_world(viewer=False)
+
+    #########
+    options = {
+        'debug' : args.debug,
+        'diagnosis' : args.diagnosis,
+        'verbose' : not args.quiet,
+        'gantry_attempts' : 100, # number of gantry sampling attempts when computing IK
+        'solve_timeout': 1200,
+        'rrt_iterations': 100,
+        'check_sweeping_collision': True,
+        'use_stored_seed' : args.use_stored_seed,
+    }
+    # ! frame, conf compare, joint flip tolerances are set here
+    options.update(get_tolerances(robot, low_res=False))
+    if not args.no_smooth:
+        options.update({
+            'smooth_iterations' : 150,
+            'max_smooth_time' : 180,
+             })
+
+    #########
+    # * Load process and recompute actions and states
+    # ! parse the WIP process file
+    process = parse_process(args.design_dir, args.problem, subdir=args.problem_subdir)
+    beam_ids = beam_ids_from_argparse_seq_n(process, None, movement_id=args.movement_id)
+
+    # * archive the target movements
+    result_path = get_process_path(args.design_dir, args.problem, subdir=args.problem_subdir)
+    ext_movement_path = os.path.dirname(result_path)
+    # archive_movements(process, beam_ids, ext_movement_path, movement_id=args.movement_id)
+
+    # ! parse the original, unplanned process file
+    source_process = parse_process(args.design_dir, args.problem, subdir='.')
+
+    # ! reset target movements from the original, unplanned process file
+    reset_movements(source_process, process, beam_ids, movement_id=args.movement_id, options=options)
+
+    set_initial_state(client, robot, process, reinit_tool=False, initialize=True)
+    solve_for_movement(client, robot, process, args, options)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR contains the following changes:

1. the polyline collision check for the attached tools is enabled by default for all the **free** motion plannings and **smoothing**.  The `check_sweeping_collision` key in the options is dedicated to this.
2. `use_stored_seed` option is available in `run.py` (defaults to be False) for reusing existing seed value from a movement. Note that when `use_stored_seed = False`, we assign `hash(time.time())` to the `movement.seed`. Thus, each planned movement will always have a saved seed with it. 