### PR TITLE
Changed API for Start End Config Problem

### DIFF
--- a/src/integral_timber_joints/planning/parsing.py
+++ b/src/integral_timber_joints/planning/parsing.py
@@ -108,7 +108,7 @@ def save_process(design_dir, process_name, _process, save_dir='results', include
     if not include_traj_in_process:
         for m in process.movements:
             if isinstance(m, RoboticMovement):
-                m.trajectory = None
+                process.set_movement_trajectory(m, None)
     with open(process_file_path, 'w') as f:
         json.dump(process, f, cls=DataEncoder, indent=indent, sort_keys=True)
     LOGGER.debug(colored('Process written to {}'.format(process_file_path), 'green'))

--- a/src/integral_timber_joints/planning/run.py
+++ b/src/integral_timber_joints/planning/run.py
@@ -50,6 +50,8 @@ def plan_for_beam_id_with_restart(client, robot, process, beam_id, args, options
 
     # ! parse the original, unplanned process file
     source_process = parse_process(args.design_dir, args.problem, subdir='.')
+    result_path = get_process_path(args.design_dir, args.problem, subdir=args.problem_subdir)
+    ext_movement_path = os.path.dirname(result_path)
 
     start_time = time.time()
     trial_i = 0
@@ -58,16 +60,11 @@ def plan_for_beam_id_with_restart(client, robot, process, beam_id, args, options
         # * parse the WIP process json saved in the problem_subdir
         process = parse_process(args.design_dir, args.problem, subdir=args.problem_subdir)
 
+        # * load previously planned movements
+        process.load_external_movements(ext_movement_path)
+
         # ! reset target movements from the original, unplanned process file
         reset_movements(source_process, process, [beam_id], movement_id=args.movement_id, options=options)
-
-        # # * load previously planned movements
-        # loaded_movements = process.load_external_movements(ext_movement_path)
-        # if len(loaded_movements) == 0:
-        #     LOGGER.warning('No external movements loaded from {}'.format(ext_movement_path))
-        if ignore_taught_confs:
-            for m in process.movements:
-                process.set_movement_end_robot_config(m, None)
 
         # * set to initial state without initialization (importing tools etc. as collision objects from files)
         set_initial_state(client, robot, process, initialize=False)
@@ -171,27 +168,6 @@ def compute_movements_for_beam_id(client, robot, process, beam_id, args, options
                 # * compute for movement_id movement
                 LOGGER.info('Computing only for {}'.format(args.movement_id))
                 options['movement_id_filter'] = [args.movement_id]
-                # ! allow for both integer-based index and string names
-                if args.movement_id.startswith('A'):
-                    chosen_m = process.get_movement_by_movement_id(args.movement_id)
-                else:
-                    chosen_m = process.movements[int(args.movement_id)]
-                # * if linear movement and has both end specified, ask user keep start or end
-                if get_movement_status(process, chosen_m, [RoboticLinearMovement]) in [MovementStatus.has_traj, MovementStatus.both_done]:
-                    chosen_m.trajectory = None
-                    keep_end = int(input("Keep start or end conf? Enter 0 for start, 1 for end. 2 for abandoning both."))
-                    if keep_end == 0:
-                        # keep start
-                        process.set_movement_end_robot_config(chosen_m, None)
-                    elif keep_end == 1:
-                        process.set_movement_start_robot_config(chosen_m, None)
-                    elif keep_end == 2:
-                        process.set_movement_start_robot_config(chosen_m, None)
-                        process.set_movement_end_robot_config(chosen_m, None)
-                        assert get_movement_status(process, chosen_m, [RoboticLinearMovement]) in [MovementStatus.neither_done]
-                    if keep_end != 2:
-                        assert get_movement_status(process, chosen_m, [RoboticLinearMovement]) in [MovementStatus.one_sided]
-
                 success, solved_movements = compute_selected_movements(client, robot, process, beam_id, 0, [],
                     None, options=options, diagnosis=args.diagnosis)
                 if not success:

--- a/src/integral_timber_joints/planning/smoothing.py
+++ b/src/integral_timber_joints/planning/smoothing.py
@@ -119,7 +119,7 @@ def main():
                     wait_if_gui('Trajectory before smoothing. Press enter to start.')
                     visualize_movement_trajectory(client, robot, process, m, step_sim=args.step_sim,
                         draw_polylines=True, line_color=pp.RED)
-                m.trajectory = smoothed_traj
+                process.set_movement_trajectory(m, smoothed_traj)
                 altered_movements.append(m)
                 if args.watch:
                     print('>'*20)

--- a/src/integral_timber_joints/planning/solve.py
+++ b/src/integral_timber_joints/planning/solve.py
@@ -159,9 +159,7 @@ def compute_movement(client, robot, process, movement, options=None, diagnosis=F
         if prev_robot_conf is not None and not is_configurations_close(prev_robot_conf, traj.points[0], options=options):
             LOGGER.error('Planned trajectory\'s first conf does not agree with the previous movement\'s end conf! Planning fails.')
             return False
-        movement.trajectory = traj
-        process.set_movement_start_robot_config(movement, traj.points[0])
-        process.set_movement_end_robot_config(movement, traj.points[-1])
+        process.set_movement_trajectory(movement, traj)
         return True
     else:
         notify('Planning fails! Go back to the command line now!')

--- a/src/integral_timber_joints/process/robot_clamp_assembly_process.py
+++ b/src/integral_timber_joints/process/robot_clamp_assembly_process.py
@@ -1300,8 +1300,6 @@ class RobotClampAssemblyProcess(Data):
         else:
             return None
 
-
-
     def set_movement_trajectory(self, movement, trajectory):
         # type: (Movement, JointTrajectory) -> None
         """Set the trajectory of a movement.

--- a/src/integral_timber_joints/rhino/visualize_movement.py
+++ b/src/integral_timber_joints/rhino/visualize_movement.py
@@ -243,9 +243,9 @@ def ui_save_ik(process):
 
     # * Save IK
     all_movements = process.movements
-    prev_movement = all_movements[movement_id]
+    prev_movement = all_movements[movement_id] # type: RoboticMovement
     if movement_id in process.temp_ik and process.temp_ik[movement_id] is not None:
-        process.set_movement_end_robot_config(prev_movement, process.temp_ik[movement_id])
+        prev_movement.target_configuration = process.temp_ik[movement_id]
         print("IK Saved at end of %s : %s" % (prev_movement.__class__.__name__, prev_movement.tag))
         del process.temp_ik[movement_id]
 


### PR DESCRIPTION
Fixes #153

@yijiangh can you please change the code in planning. You can search and remove `set_movement_end_robot_config()`, `set_movement_start_robot_config()` . And change all your write access to movement.trajectory to use `set_movement_trajectory()`